### PR TITLE
Fix: #66 Search.xml URLs double slashes

### DIFF
--- a/lib/xml_generator.js
+++ b/lib/xml_generator.js
@@ -39,12 +39,19 @@ module.exports = function(locals){
     posts = locals.posts.sort('-date');
   }
 
+  var rootURL;
+  if (config.root == "/" || config.root == null){
+    rootURL = "";
+  }else{
+    rootURL = config.root;
+  }
+
   var xml = template.render({
     config: config,
     posts: posts,
     pages: pages,
     content: content,
-    url: config.root
+    url: rootURL
   });
 
   return {


### PR DESCRIPTION
I believe this PR will fix #66, I tried to implement my solution proposal which I explained [here](https://github.com/wzpan/hexo-generator-search/issues/66#issuecomment-687716702).

My initial tests show that fix is working, but I do not know any JavaScript. Therefore, my fix could be pretty straight forward and may need to be optimized.